### PR TITLE
Adds the word issues after the counter

### DIFF
--- a/scripts/filter.js
+++ b/scripts/filter.js
@@ -76,7 +76,7 @@ function createCheckBoxFromCounter(counter, title, attrId) {
         item_text.append(document.createTextNode(item));
 
         let count_text = document.createElement("span");
-        count_text.append(document.createTextNode(" (" + count.toString() + ")"));
+        count_text.append(document.createTextNode(" (" + count.toString() + " issues" + ")"));
 
         checkbox_text.appendChild(item_text);
         checkbox_text.appendChild(count_text);

--- a/scripts/filter.js
+++ b/scripts/filter.js
@@ -76,7 +76,12 @@ function createCheckBoxFromCounter(counter, title, attrId) {
         item_text.append(document.createTextNode(item));
 
         let count_text = document.createElement("span");
-        count_text.append(document.createTextNode(" (" + count.toString() + " issues" + ")"));
+
+        if (count > 1) {
+            count_text.append(document.createTextNode(" (" + count.toString() + " issues" + ")"));
+        } else {
+            count_text.append(document.createTextNode(" (" + count.toString() + " issue" + ")"));
+        }
 
         checkbox_text.appendChild(item_text);
         checkbox_text.appendChild(count_text);


### PR DESCRIPTION
Hello everyone!

The possibility of filtering alphabetically and putting `... (x issues)` in the dropdown was being discussed in #38.

I couldn't put it in alphabetical order, but I was able to include the word issues after the counter.

This PR also adds to `Filter by Issue Label` and `Filter by Repository`.

This partially resolves #38.

If it's interesting, consider merging. 😉

<img width="413" alt="issues-conter" src="https://user-images.githubusercontent.com/17712401/148497150-6353223f-9b5b-48c2-ad7e-0da28392096d.png">
