### PR TITLE
Fixed second scrollbar appearing on tooltip hover

### DIFF
--- a/styles/cover.css
+++ b/styles/cover.css
@@ -40,11 +40,11 @@ html,
 body {
   height: 100%;
   background-color: #282c34;
-  overflow-y: auto;
 }
 
 html {
   font-size: 1rem;
+  overflow-y: hidden;
 }
 
 body {
@@ -52,6 +52,7 @@ body {
   display: flex;
   color: #F6F6F9;
   box-shadow: inset 0 0 5rem rgba(0, 0, 0, .5);
+  overflow-y: auto;
 }
 
 .cover-container {


### PR DESCRIPTION
On desktop, I noticed if the user hovers over the tooltip and the tooltip description runs off the page, a second vertical scrollbar appears.  

The overflow-y on the html was switched hidden.  If it was removed then the background's box shadow effect stays static at the top of the page