### PR TITLE
Fixed failing workflow

### DIFF
--- a/.github/workflows/go-write-to-file.yml
+++ b/.github/workflows/go-write-to-file.yml
@@ -20,16 +20,7 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-    
-    - name: Cache dependencies
-      id: get-dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    
+
     - name: Get dependencies
       if: steps.get-dependencies.outputs.cache-hit != 'true'
       run: go get github.com/shurcooL/githubv4 golang.org/x/oauth2

--- a/.github/workflows/go-write-to-file.yml
+++ b/.github/workflows/go-write-to-file.yml
@@ -11,20 +11,16 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.13
       id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-  
-    - run: rm -f /home/runner/go/src/* 
-
     - name: Get dependencies
-      if: steps.get-dependencies.outputs.cache-hit != 'true'
+      if: steps.go.outputs.cache-hit == 'false'
       run: go get github.com/shurcooL/githubv4 golang.org/x/oauth2
       
     - name: Build

--- a/.github/workflows/go-write-to-file.yml
+++ b/.github/workflows/go-write-to-file.yml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+  
+    - run: rm -f /home/runner/go/src/* 
 
     - name: Get dependencies
       if: steps.get-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/go-write-to-file.yml
+++ b/.github/workflows/go-write-to-file.yml
@@ -28,9 +28,9 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-          
+    
     - name: Get dependencies
-      # if: steps.cget-dependencies.outputs.cache-hit != 'true'
+      if: steps.get-dependencies.outputs.cache-hit != 'true'
       run: go get github.com/shurcooL/githubv4 golang.org/x/oauth2
       
     - name: Build


### PR DESCRIPTION
- Fixes issue #49 

The workflow was failing because of multiple instances of the same dependency, which is not allowed in Go. The fix is to check if the dependency already exists and download only if there's a cache miss