### PR TITLE
Enhancing UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "goodfirstissues",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/scripts/list_item.js
+++ b/scripts/list_item.js
@@ -51,13 +51,24 @@ function createListGroupItemForIssue(issue) {
     heading_div.setAttribute("class", "d-flex justify-content-between");
 
     // Issue's title
+    // Create the h5 container
     let heading_h5 = document.createElement("h5");
-    heading_h5.setAttribute("class",
-        "issue-title mb-0 d-inline-block text-truncate");
+    heading_h5.setAttribute("class", "issue-title mb-0 d-inline-block text-truncate");
     heading_h5.setAttribute("aria-label", `Issue: ${issue_title}`);
-    let issue_title_textnode = document.createTextNode(issue_title);
-    heading_h5.appendChild(issue_title_textnode);
+
+    // Create the anchor tag for the clickable issue title
+    let issue_link = document.createElement("a");
+    issue_link.setAttribute("href", issue_url);
+    issue_link.setAttribute("target", "_blank");
+    issue_link.setAttribute("class", "text-decoration-none text-dark"); // Optional styling
+    issue_link.textContent = issue_title;
+
+    // Append the link inside the h5
+    heading_h5.appendChild(issue_link);
+
+    // Append the h5 to its container
     heading_div.appendChild(heading_h5);
+
 
     // Time of issue
     let time_of_issue = document.createElement("p");


### PR DESCRIPTION
🛠️ Issue: Make Issue Title Clickable in UI
📌 Description:
Currently, the issue title is displayed as plain text using an <h5> element. Users must click a separate "Go to Issue" button to open the issue on GitHub.

This issue proposes enhancing the user experience by making the issue title itself a clickable link that opens the original issue in a new tab. This will reduce friction for users trying to explore issues quickly.

✅ Proposed Change:
Wrap the issue_title inside an <a> tag with the href set to issue_url.

Ensure accessibility and responsiveness are preserved.

Maintain the existing styling and use appropriate Bootstrap utility classes.
 